### PR TITLE
Restore Cython acceleration for geometric routines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.so
+*.dylib
+.DS_Store
+.venv/
+.eggs/
+build/
+dist/
+*.egg-info/
+.ipynb_checkpoints/

--- a/CGALDelaunay/README.md
+++ b/CGALDelaunay/README.md
@@ -1,0 +1,12 @@
+# CGAL helper binaries
+
+This directory should contain the compiled CGAL helper executables:
+
+- `EdgesCGALWeightedDelaunay2D`
+- `EdgesCGALWeightedDelaunay3D`
+- `EdgesCGALWeightedDelaunayND`
+- `EdgesCGALDelaunay2D`
+- `EdgesCGALDelaunay3D`
+- `EdgesCGALDelaunayND`
+
+Run `./scripts/setup_cgal.py` to clone the corresponding repositories here. After cloning, build each project with CMake following their respective README instructions. HypergraphPercol expects the executables to live in `build/` inside each project folder.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,90 @@
+# HypergraphPercol
+
+HypergraphPercol is a research-grade clustering algorithm based on hypergraph percolation. This repository turns the original research notebook into a reusable Python package with a reproducible project layout, documentation, and examples.
+
+## Features
+
+- Weighted Delaunay / order-k Delaunay support via CGAL helper binaries
+- Integration with HDBSCAN for hierarchical cluster extraction
+- Optional PCA / UMAP dimensionality reduction pipeline
+- Parallel radius computation using [`miniball`](https://pypi.org/project/MiniballCpp/)
+- Example script showing end-to-end usage on synthetic data
+
+## Project layout
+
+```
+CGALDelaunay/           # Expected location of CGAL helper projects (see below)
+examples/demo.py        # Minimal demonstration of HypergraphPercol
+scripts/setup_cgal.py   # Utility to clone the CGAL helper repositories
+src/hypergraphpercol/   # Python package
+└── core.py             # Main HypergraphPercol implementation
+```
+
+## Installation
+
+1. Clone this repository and the CGAL helper executables:
+
+   ```bash
+   git clone https://github.com/your-user/HypergraphPercol.git
+   cd HypergraphPercol
+   python -m venv .venv && source .venv/bin/activate
+   pip install -U pip
+   pip install -e .
+   ./scripts/setup_cgal.py
+   ```
+
+   The helper script clones the six repositories containing the prebuilt CGAL executables into `CGALDelaunay/`. If you already have them, place them in that directory or set the `CGALDELAUNAY_ROOT` environment variable to point to their location.
+
+   > **Note**
+   > The editable install step compiles a small Cython extension that accelerates key geometric routines. Ensure a C/C++ toolchain and Python headers are available on your platform.
+
+2. Install optional extras (if you need UMAP-based dimensionality reduction):
+
+   ```bash
+   pip install umap-learn
+   ```
+
+## Usage
+
+```python
+import numpy as np
+from hypergraphpercol import HypergraphPercol
+
+X = np.random.random((200, 3))
+labels = HypergraphPercol(
+    X,
+    K=2,
+    min_cluster_size=30,
+    min_samples=5,
+    metric="euclidean",
+    complex_chosen="auto",
+    expZ=2,
+    precision="safe",
+    verbeux=True,
+    cgal_root="./CGALDelaunay",
+)
+```
+
+The `cgal_root` argument is optional; when omitted, the package searches for the helper binaries inside `CGALDelaunay/` relative to the repository root or uses the `CGALDELAUNAY_ROOT` environment variable.
+
+Set `return_multi_clusters=True` to obtain, for each point, the list of candidate clusters with membership probability.
+
+## Example
+
+Run the demo script to build a synthetic dataset and cluster it:
+
+```bash
+python examples/demo.py
+```
+
+## Testing
+
+You can verify the installation with the included unit tests:
+
+```bash
+pytest
+```
+
+## License
+
+The Python code in this repository is released under the MIT License. The CGAL helper projects keep their original licenses.

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -1,0 +1,42 @@
+"""Small demonstration of the HypergraphPercol clustering algorithm."""
+
+from __future__ import annotations
+
+import pathlib
+
+import numpy as np
+
+from hypergraphpercol import HypergraphPercol
+
+
+def make_dataset(seed: int = 0) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    blobs = []
+    centers = [(-4, -4), (0, 0), (5, 4)]
+    for cx, cy in centers:
+        blobs.append(rng.normal(loc=(cx, cy), scale=0.7, size=(80, 2)))
+    return np.vstack(blobs)
+
+
+def main() -> None:
+    data = make_dataset()
+    repo_root = pathlib.Path(__file__).resolve().parents[1]
+    cgal_root = repo_root / "CGALDelaunay"
+    labels = HypergraphPercol(
+        data,
+        K=2,
+        min_cluster_size=20,
+        min_samples=4,
+        metric="euclidean",
+        complex_chosen="auto",
+        expZ=2,
+        precision="safe",
+        verbeux=False,
+        cgal_root=cgal_root,
+    )
+    print("Cluster labels:")
+    print(labels)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,37 @@
+[build-system]
+requires = [
+  "setuptools>=64",
+  "wheel",
+  "Cython>=0.29.36",
+  "numpy>=1.24",
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "hypergraphpercol"
+version = "0.1.0"
+description = "Hypergraph-based clustering algorithm"
+authors = [{ name = "HypergraphPercol" }]
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.9"
+dependencies = [
+  "numpy>=1.24",
+  "scikit-learn>=1.3",
+  "joblib>=1.3",
+  "hdbscan>=0.8",
+  "gudhi>=3.10",
+  "MiniballCpp>=1.0",
+]
+
+[project.optional-dependencies]
+umap = ["umap-learn>=0.5"]
+
+[project.urls]
+Homepage = "https://github.com/your-user/HypergraphPercol"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/scripts/setup_cgal.py
+++ b/scripts/setup_cgal.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REPOS = [
+    "https://github.com/Ludwig-H/EdgesCGALWeightedDelaunay3D.git",
+    "https://github.com/Ludwig-H/EdgesCGALWeightedDelaunay2D.git",
+    "https://github.com/Ludwig-H/EdgesCGALWeightedDelaunayND.git",
+    "https://github.com/Ludwig-H/EdgesCGALDelaunay3D.git",
+    "https://github.com/Ludwig-H/EdgesCGALDelaunay2D.git",
+    "https://github.com/Ludwig-H/EdgesCGALDelaunayND.git",
+]
+
+
+def main() -> None:
+    root = Path(__file__).resolve().parents[1] / "CGALDelaunay"
+    root.mkdir(exist_ok=True)
+    for url in REPOS:
+        name = url.rstrip("/").split("/")[-1].removesuffix(".git")
+        dest = root / name
+        if dest.exists():
+            print(f"[skip] {name} already exists")
+            continue
+        print(f"[clone] {url} -> {dest}")
+        subprocess.run(["git", "clone", "--depth", "1", url, str(dest)], check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy
+from Cython.Build import cythonize
+from setuptools import Extension, setup
+
+
+EXTENSIONS = [
+    Extension(
+        "hypergraphpercol._cython",
+        sources=[str(Path("src") / "hypergraphpercol" / "_cython.pyx")],
+        include_dirs=[numpy.get_include()],
+        define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
+    )
+]
+
+
+setup(ext_modules=cythonize(EXTENSIONS, language_level="3"))

--- a/src/hypergraphpercol/__init__.py
+++ b/src/hypergraphpercol/__init__.py
@@ -1,0 +1,5 @@
+"""HypergraphPercol clustering package."""
+
+from .core import HypergraphPercol
+
+__all__ = ["HypergraphPercol"]

--- a/src/hypergraphpercol/_cython.pyx
+++ b/src/hypergraphpercol/_cython.pyx
@@ -1,0 +1,256 @@
+# cython: language_level=3
+# cython: boundscheck=False
+# cython: nonecheck=False
+# cython: initializedcheck=False
+"""Cython utilities for HypergraphPercol."""
+
+import numpy as np
+cimport numpy as np
+
+
+cdef class UnionFind:
+    cdef np.intp_t[:] parent
+    cdef np.intp_t[:] _size
+
+    def __init__(self, int n):
+        self.parent = np.arange(n, dtype=np.intp)
+        self._size = np.ones(n, dtype=np.intp)
+
+    cpdef int find(self, int x):
+        cdef int r = x
+        while self.parent[r] != r:
+            r = self.parent[r]
+        cdef int cur = x
+        cdef int nxt
+        while self.parent[cur] != r:
+            nxt = self.parent[cur]
+            self.parent[cur] = r
+            cur = nxt
+        return r
+
+    cpdef bint union(self, int x, int y):
+        cdef int rx = self.find(x)
+        cdef int ry = self.find(y)
+        if rx == ry:
+            return False
+        if self._size[rx] < self._size[ry]:
+            self.parent[rx] = ry
+            self._size[ry] += self._size[rx]
+        else:
+            self.parent[ry] = rx
+            self._size[rx] += self._size[ry]
+        return True
+
+    cpdef int component_size(self, int x):
+        return self._size[self.find(x)]
+
+
+ctypedef np.double_t DTYPE_t
+ctypedef np.int64_t ITYPE_t
+
+
+cpdef double bary_weight_one(
+    DTYPE_t[:, ::1] M,
+    DTYPE_t[::1] s2_all,
+    ITYPE_t[::1] idx,
+    DTYPE_t[::1] out_q,
+):
+    cdef Py_ssize_t k = idx.shape[0]
+    cdef Py_ssize_t d = M.shape[1]
+    cdef Py_ssize_t i, t
+    cdef double smean = 0.0
+    cdef double qnorm2 = 0.0
+    cdef ITYPE_t ii
+
+    for t in range(d):
+        out_q[t] = 0.0
+
+    for i in range(k):
+        ii = idx[i]
+        smean += s2_all[ii]
+        for t in range(d):
+            out_q[t] += M[ii, t]
+
+    for t in range(d):
+        out_q[t] /= k
+        qnorm2 += out_q[t] * out_q[t]
+
+    smean /= k
+    return qnorm2 - smean
+
+
+cpdef void bary_weight_batch(
+    DTYPE_t[:, ::1] M,
+    DTYPE_t[::1] s2_all,
+    ITYPE_t[:, ::1] combos,
+    DTYPE_t[:, ::1] out_Q,
+    DTYPE_t[::1] out_w,
+):
+    cdef Py_ssize_t m = combos.shape[0]
+    cdef Py_ssize_t k = combos.shape[1]
+    cdef Py_ssize_t d = M.shape[1]
+    cdef Py_ssize_t i, j, t
+    cdef double smean, qnorm2
+    cdef ITYPE_t ii
+
+    for i in range(m):
+        smean = 0.0
+        for t in range(d):
+            out_Q[i, t] = 0.0
+        for j in range(k):
+            ii = combos[i, j]
+            smean += s2_all[ii]
+            for t in range(d):
+                out_Q[i, t] += M[ii, t]
+        for t in range(d):
+            out_Q[i, t] /= k
+        smean /= k
+        qnorm2 = 0.0
+        for t in range(d):
+            qnorm2 += out_Q[i, t] * out_Q[i, t]
+        out_w[i] = qnorm2 - smean
+
+
+cpdef int union_if_adjacent_int(
+    ITYPE_t[::1] a,
+    ITYPE_t[::1] b,
+    ITYPE_t[::1] out_u,
+):
+    cdef Py_ssize_t k = a.shape[0]
+    cdef Py_ssize_t i = 0
+    cdef Py_ssize_t j = 0
+    cdef Py_ssize_t u = 0
+
+    while i < k and j < k:
+        if u >= out_u.shape[0]:
+            return 0
+        if a[i] == b[j]:
+            out_u[u] = a[i]
+            i += 1
+            j += 1
+            u += 1
+        elif a[i] < b[j]:
+            out_u[u] = a[i]
+            i += 1
+            u += 1
+        else:
+            out_u[u] = b[j]
+            j += 1
+            u += 1
+
+    while i < k:
+        if u >= out_u.shape[0]:
+            return 0
+        out_u[u] = a[i]
+        i += 1
+        u += 1
+
+    while j < k:
+        if u >= out_u.shape[0]:
+            return 0
+        out_u[u] = b[j]
+        j += 1
+        u += 1
+
+    return 1 if u == k + 1 else 0
+
+
+cdef inline np.int64_t _min_i64(np.int64_t a, np.int64_t b) nogil:
+    return a if a <= b else b
+
+
+cdef inline np.int64_t _max_i64(np.int64_t a, np.int64_t b) nogil:
+    return a if a >= b else b
+
+
+cpdef tuple build_leaf_dfs_intervals(
+    np.ndarray[np.int64_t, ndim=1] left,
+    np.ndarray[np.int64_t, ndim=1] right,
+):
+    cdef Py_ssize_t t = left.shape[0]
+    if right.shape[0] != t:
+        raise ValueError("left/right must have same length")
+    cdef Py_ssize_t m = t + 1
+    cdef Py_ssize_t n_nodes = m + t
+
+    cdef np.int64_t[:] L = left
+    cdef np.int64_t[:] R = right
+
+    cdef np.ndarray[np.int64_t, ndim=1] first = np.empty(n_nodes, dtype=np.int64)
+    cdef np.ndarray[np.int64_t, ndim=1] last = np.empty(n_nodes, dtype=np.int64)
+    cdef np.ndarray[np.int64_t, ndim=1] leaf_order = np.empty(m, dtype=np.int64)
+    cdef np.ndarray[np.int64_t, ndim=1] pos = np.empty(m, dtype=np.int64)
+
+    cdef np.int64_t[:] first_v = first
+    cdef np.int64_t[:] last_v = last
+    cdef np.int64_t[:] lo_v = leaf_order
+    cdef np.int64_t[:] pos_v = pos
+
+    cdef Py_ssize_t i
+    for i in range(n_nodes):
+        first_v[i] = -1
+        last_v[i] = -1
+
+    cdef np.ndarray[np.int64_t, ndim=1] stack_node = np.empty(n_nodes, dtype=np.int64)
+    cdef np.ndarray[np.int8_t, ndim=1] stack_st = np.empty(n_nodes, dtype=np.int8)
+    cdef np.int64_t[:] st_node = stack_node
+    cdef np.int8_t[:] st_st = stack_st
+
+    cdef Py_ssize_t sp = 0
+    cdef np.int64_t root = m + t - 1
+    st_node[sp] = root
+    st_st[sp] = 0
+    sp += 1
+
+    cdef Py_ssize_t k = 0
+    cdef np.int64_t x, state, child_idx, a, b, fa, fb, la, lb
+
+    while sp > 0:
+        sp -= 1
+        x = st_node[sp]
+        state = st_st[sp]
+
+        if x < m:
+            first_v[x] = k
+            last_v[x] = k
+            lo_v[k] = x
+            k += 1
+            continue
+
+        child_idx = x - m
+        if not (0 <= child_idx < t):
+            raise ValueError("Invalid internal node index")
+
+        if state == 0:
+            st_node[sp] = x
+            st_st[sp] = 1
+            sp += 1
+            b = R[child_idx]
+            a = L[child_idx]
+            if a >= x or b >= x or a < 0 or b < 0:
+                raise ValueError("SciPy linkage convention violated: child >= parent")
+            st_node[sp] = b
+            st_st[sp] = 0
+            sp += 1
+            st_node[sp] = a
+            st_st[sp] = 0
+            sp += 1
+        else:
+            a = L[child_idx]
+            b = R[child_idx]
+            fa = first_v[a]
+            fb = first_v[b]
+            la = last_v[a]
+            lb = last_v[b]
+            if fa == -1 or fb == -1:
+                raise ValueError("Invalid tree: child interval not computed")
+            first_v[x] = _min_i64(fa, fb)
+            last_v[x] = _max_i64(la, lb)
+
+    if k != m:
+        raise ValueError("Leaf DFS did not visit all leaves")
+
+    for i in range(m):
+        pos_v[lo_v[i]] = i
+
+    return pos, first, last, leaf_order

--- a/src/hypergraphpercol/clustering.py
+++ b/src/hypergraphpercol/clustering.py
@@ -1,0 +1,563 @@
+from __future__ import annotations
+from collections import defaultdict
+from typing import Iterable, Sequence
+
+import numpy as np
+
+from .union_find import UnionFind
+
+try:  # pragma: no cover - prefer compiled implementation
+    from ._cython import build_leaf_dfs_intervals as _cython_build_leaf_dfs_intervals  # type: ignore
+except ImportError:  # pragma: no cover - fallback used when extension unavailable
+    _cython_build_leaf_dfs_intervals = None
+
+
+def tree_to_labels(
+    single_linkage_tree: np.ndarray,
+    *,
+    min_cluster_size: int = 20,
+    DBSCAN_threshold: float | None = None,
+    cluster_selection_method: str = "eom",
+    allow_single_cluster: bool = True,
+    match_reference_implementation: bool = False,
+    cluster_selection_epsilon: float = 0.0,
+    cluster_selection_persistence: float = 0.0,
+    max_cluster_size: int = 0,
+    cluster_selection_epsilon_max: float = float("inf"),
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    try:
+        from hdbscan._hdbscan_tree import condense_tree, compute_stability, get_clusters
+    except ModuleNotFoundError as exc:  # pragma: no cover
+        raise ModuleNotFoundError(
+            "hdbscan is required to convert trees into cluster labels"
+        ) from exc
+
+    condensed = condense_tree(single_linkage_tree, min_cluster_size)
+    stability = compute_stability(condensed)
+    if DBSCAN_threshold is None:
+        labels, probabilities, stabilities = get_clusters(
+            condensed,
+            stability,
+            cluster_selection_method,
+            allow_single_cluster,
+            match_reference_implementation,
+            cluster_selection_epsilon,
+            max_cluster_size,
+            cluster_selection_epsilon_max,
+        )
+    else:
+        labels, probabilities, stabilities = get_clusters(
+            condensed,
+            stability,
+            "leaf",
+            allow_single_cluster,
+            match_reference_implementation,
+            DBSCAN_threshold,
+            max_cluster_size,
+            DBSCAN_threshold,
+        )
+    return labels, probabilities, stabilities, condensed, single_linkage_tree
+
+
+def _build_leaf_dfs_intervals_python(
+    left: np.ndarray, right: np.ndarray
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    t = int(left.size)
+    m = t + 1
+    n_nodes = m + t
+    first = np.full(n_nodes, -1, dtype=np.int64)
+    last = np.full(n_nodes, -1, dtype=np.int64)
+    leaf_order = np.empty(m, dtype=np.int64)
+    root = m + t - 1
+    stack: list[tuple[int, int]] = [(int(root), 0)]
+    k = 0
+    while stack:
+        node, state = stack.pop()
+        if node < m:
+            first[node] = last[node] = k
+            leaf_order[k] = node
+            k += 1
+        else:
+            idx = node - m
+            if state == 0:
+                stack.append((node, 1))
+                stack.append((int(right[idx]), 0))
+                stack.append((int(left[idx]), 0))
+            else:
+                a = int(left[idx])
+                b = int(right[idx])
+                fa = int(first[a])
+                fb = int(first[b])
+                la = int(last[a])
+                lb = int(last[b])
+                if fa == -1 or fb == -1:
+                    raise RuntimeError("Invalid tree: child interval missing")
+                first[node] = fa if fa <= fb else fb
+                last[node] = la if la >= lb else lb
+    if k != m:
+        raise RuntimeError("DFS traversal did not visit all leaves")
+    pos = np.empty(m, dtype=np.int64)
+    pos[leaf_order] = np.arange(m, dtype=np.int64)
+    return pos, first, last, leaf_order
+
+
+def build_leaf_dfs_intervals(
+    left: np.ndarray, right: np.ndarray
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    left64 = np.asarray(left, dtype=np.int64)
+    right64 = np.asarray(right, dtype=np.int64)
+    if _cython_build_leaf_dfs_intervals is not None:
+        return _cython_build_leaf_dfs_intervals(left64, right64)
+    return _build_leaf_dfs_intervals_python(left64, right64)
+
+
+def prune_linkage_by_inclusion(Z_full: np.ndarray, K: int, verbose: bool = False) -> tuple[np.ndarray, np.ndarray]:
+    Z = np.asarray(Z_full, dtype=np.float64, order="C")
+    t = int(Z.shape[0])
+    m = t + 1
+    if m <= 1:
+        return np.zeros((0, 4), np.float64), np.array([0], dtype=np.int64)
+    left = Z[:, 0].astype(np.int64, copy=False)
+    right = Z[:, 1].astype(np.int64, copy=False)
+    weight = Z[:, 2].astype(np.float64, copy=False)
+    usize = np.rint(Z[:, 3]).astype(np.int64, copy=False)
+    for i in range(t):
+        parent = m + i
+        a = int(left[i])
+        b = int(right[i])
+        if not (0 <= a < parent and 0 <= b < parent):
+            raise ValueError("SciPy linkage convention violated: child >= parent")
+    n_nodes = m + t
+    size_node = np.zeros(n_nodes, dtype=np.int64)
+    size_node[:m] = int(K)
+    size_node[m:] = usize
+    inc = np.zeros(t, dtype=bool)
+    for i in range(t):
+        a = int(left[i])
+        b = int(right[i])
+        p = m + i
+        sa = int(size_node[a])
+        sb = int(size_node[b])
+        su = int(size_node[p])
+        inc[i] = su == (sa if sa >= sb else sb)
+    pos, first, last, leaf_order = build_leaf_dfs_intervals(left, right)
+    UF = UnionFind(m)
+    nxt = np.arange(m + 1, dtype=np.int64)
+
+    def _next(idx: int) -> int:
+        j = idx
+        while nxt[j] != j:
+            nxt[j] = nxt[nxt[j]]
+            j = nxt[j]
+        return j
+
+    def union_interval(L: int, R: int, to_pos: int) -> None:
+        root_to = UF.find(to_pos)
+        i = _next(L)
+        while i <= R:
+            UF.union(i, root_to)
+            nxt[i] = _next(i + 1)
+            i = nxt[i]
+
+    for i in range(t):
+        if not inc[i]:
+            continue
+        a = int(left[i])
+        b = int(right[i])
+        sa = int(size_node[a])
+        sb = int(size_node[b])
+        winner = a if sa >= sb else b
+        loser = b if sa >= sb else a
+        Lw, Rw = int(first[winner]), int(last[winner])
+        Ll, Rl = int(first[loser]), int(last[loser])
+        rep_pos = UF.find(Lw)
+        union_interval(Ll, Rl, rep_pos)
+
+    rep_pos = np.array([UF.find(i) for i in range(m)], dtype=np.int64)
+    uniq_rep, inverse = np.unique(rep_pos, return_inverse=True)
+    Lp = int(uniq_rep.size)
+    cls_of_pos = inverse
+    min_pos_per_class = np.full(Lp, m + 1, dtype=np.int64)
+    for p in range(m):
+        c = int(cls_of_pos[p])
+        if p < min_pos_per_class[c]:
+            min_pos_per_class[c] = p
+    surv_idx = leaf_order[min_pos_per_class]
+    if Lp <= 1:
+        return np.zeros((0, 4), np.float64), surv_idx
+    U: list[int] = []
+    V: list[int] = []
+    W: list[float] = []
+    S: list[float] = []
+    for i in range(t):
+        if inc[i]:
+            continue
+        a = int(left[i])
+        b = int(right[i])
+        La = int(first[a])
+        Lb = int(first[b])
+        ca = int(cls_of_pos[UF.find(La)])
+        cb = int(cls_of_pos[UF.find(Lb)])
+        if ca == cb:
+            continue
+        if ca > cb:
+            ca, cb = cb, ca
+        U.append(ca)
+        V.append(cb)
+        W.append(float(weight[i]))
+        S.append(float(usize[i]))
+    if not U:
+        raise RuntimeError("No non-inclusive edges between classes")
+    U_arr = np.asarray(U, dtype=np.int64)
+    V_arr = np.asarray(V, dtype=np.int64)
+    W_arr = np.asarray(W, dtype=np.float64)
+    S_arr = np.asarray(S, dtype=np.float64)
+    UFc = UnionFind(Lp)
+    comp_id = np.arange(Lp, dtype=np.int64)
+    Z_pruned = np.empty((Lp - 1, 4), dtype=np.float64)
+    created = 0
+    for i in range(U_arr.size):
+        ru = UFc.find(int(U_arr[i]))
+        rv = UFc.find(int(V_arr[i]))
+        if ru == rv:
+            continue
+        ida = int(comp_id[ru])
+        idb = int(comp_id[rv])
+        if ida > idb:
+            ida, idb = idb, ida
+        Z_pruned[created, 0] = float(ida)
+        Z_pruned[created, 1] = float(idb)
+        Z_pruned[created, 2] = float(W_arr[i])
+        Z_pruned[created, 3] = float(S_arr[i])
+        UFc.union(ru, rv)
+        root = UFc.find(ru)
+        comp_id[root] = Lp + created
+        created += 1
+        if created == Lp - 1:
+            break
+    if created != Lp - 1:
+        raise RuntimeError("Incomplete quotient after pruning")
+    if verbose:
+        print(f"[PRUNE] leaves={m}, classes={Lp}, Z_pruned shape={Z_pruned.shape}")
+    return Z_pruned, surv_idx
+
+
+def _kruskal_mst_from_edges(n_nodes: int, rows: Sequence[int], cols: Sequence[int], weights: Sequence[float], UF: UnionFind) -> list[tuple[int, int, float]]:
+    rows = np.asarray(rows, dtype=np.int64)
+    cols = np.asarray(cols, dtype=np.int64)
+    weights = np.asarray(weights, dtype=float)
+    if rows.size == 0:
+        return []
+    order = np.argsort(weights, kind="stable")
+    rows = rows[order]
+    cols = cols[order]
+    weights = weights[order]
+    mst_u = np.empty(max(0, n_nodes - 1), dtype=np.int64)
+    mst_v = np.empty_like(mst_u)
+    mst_w = np.empty_like(mst_u, dtype=float)
+    taken = 0
+    for i in range(rows.size):
+        a = int(rows[i])
+        b = int(cols[i])
+        ra = UF.find(a)
+        rb = UF.find(b)
+        if ra == rb:
+            continue
+        mst_u[taken] = a
+        mst_v[taken] = b
+        mst_w[taken] = float(weights[i])
+        UF.union(ra, rb)
+        taken += 1
+        if taken == mst_u.size:
+            break
+    return list(zip(mst_u[:taken].tolist(), mst_v[:taken].tolist(), mst_w[:taken].tolist()))
+
+
+def build_Z_mst_occurrences_gc(
+    face_vertices: np.ndarray,
+    mst_faces_sorted: Iterable[tuple[int, int, float]] | tuple[np.ndarray, np.ndarray, np.ndarray],
+    *,
+    min_cluster_size: int,
+    verbose: bool = False,
+    distinct_mode: str = "owner",
+    DBSCAN_threshold: float | None = None,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    def _fmt_bytes(n: float) -> str:
+        n = float(n)
+        for unit in ("B", "KiB", "MiB", "GiB"):
+            if n < 1024 or unit == "GiB":
+                return f"{n:.1f} {unit}" if unit != "B" else f"{n:.0f} {unit}"
+            n /= 1024
+        return f"{n:.1f} GiB"
+
+    def _rss() -> float | None:
+        try:
+            import psutil
+
+            return float(psutil.Process().memory_info().rss)
+        except Exception:
+            return None
+
+    F = np.asarray(face_vertices, dtype=np.int64, order="C")
+    m = int(F.shape[0])
+    if m == 0:
+        return np.zeros((0, 4), np.float64), np.zeros(0, np.int64), F
+    K = int(F.shape[1])
+    if isinstance(mst_faces_sorted, tuple) and len(mst_faces_sorted) == 3:
+        u_arr = np.asarray(mst_faces_sorted[0], dtype=np.int64)
+        v_arr = np.asarray(mst_faces_sorted[1], dtype=np.int64)
+        w_arr = np.asarray(mst_faces_sorted[2], dtype=np.float64)
+    else:
+        data = list(mst_faces_sorted)
+        if data:
+            u_arr = np.fromiter((u for u, _, _ in data), count=len(data), dtype=np.int64)
+            v_arr = np.fromiter((v for _, v, _ in data), count=len(data), dtype=np.int64)
+            w_arr = np.fromiter((w for _, _, w in data), count=len(data), dtype=np.float64)
+        else:
+            u_arr = v_arr = np.empty(0, dtype=np.int64)
+            w_arr = np.empty(0, dtype=np.float64)
+    if u_arr.size == 0:
+        return np.zeros((0, 4), np.float64), np.zeros(m, np.int64), F
+    order = np.argsort(w_arr, kind="stable")
+    u_arr = u_arr[order]
+    v_arr = v_arr[order]
+    w_arr = w_arr[order]
+    next_face = np.full(m, -1, dtype=np.int64)
+    head = np.arange(m, dtype=np.int64)
+    tail = np.arange(m, dtype=np.int64)
+    comp_sz = np.ones(m, dtype=np.int64)
+    UF = UnionFind(m)
+    cid = np.arange(m, dtype=np.int64)
+    nxt = int(m)
+    n_points = int(F.max()) + 1
+    owner_root = np.full(n_points, -1, dtype=np.int64)
+    distinct_count = np.zeros(m, dtype=np.int64)
+    for f in range(m):
+        row = F[f]
+        for j in range(K):
+            v = int(row[j])
+            if owner_root[v] == -1:
+                owner_root[v] = f
+                distinct_count[f] += 1
+    Z = np.empty((max(0, m - 1), 4), dtype=np.float64)
+    taken = 0
+    for a, b, w in zip(u_arr, v_arr, w_arr):
+        ra = UF.find(int(a))
+        rb = UF.find(int(b))
+        if ra == rb:
+            continue
+        sa = int(comp_sz[ra])
+        sb = int(comp_sz[rb])
+        small, big = (ra, rb) if sa < sb else (rb, ra)
+        root_big = UF.find(big)
+        uniq_add = 0
+        i = int(head[small])
+        while i != -1:
+            row = F[i]
+            for j in range(K):
+                v = int(row[j])
+                pr = owner_root[v]
+                if pr == -1 or UF.find(int(pr)) != root_big:
+                    owner_root[v] = root_big
+                    uniq_add += 1
+            i = int(next_face[i])
+        new_count = int(distinct_count[root_big]) + int(uniq_add)
+        Z[taken, 0] = float(cid[big])
+        Z[taken, 1] = float(cid[small])
+        Z[taken, 2] = float(w)
+        Z[taken, 3] = float(new_count)
+        taken += 1
+        if head[small] != -1:
+            if head[big] == -1:
+                head[big] = head[small]
+                tail[big] = tail[small]
+            else:
+                next_face[int(tail[big])] = int(head[small])
+                tail[big] = int(tail[small])
+            comp_sz[big] = comp_sz[big] + comp_sz[small]
+            head[small] = -1
+            tail[small] = -1
+            comp_sz[small] = 0
+        UF.union(big, small)
+        root = UF.find(big)
+        head[root] = head[big]
+        tail[root] = tail[big]
+        comp_sz[root] = comp_sz[big]
+        distinct_count[root] = new_count
+        cid[root] = nxt
+        nxt += 1
+        if taken == m - 1:
+            break
+    Z = Z if taken == Z.shape[0] else Z[:taken].copy()
+    Z_pruned, surv_idx = prune_linkage_by_inclusion(Z_full=Z, K=K, verbose=verbose)
+    if Z_pruned.shape[0] <= 1 or Z_pruned[-1, 3] <= min_cluster_size:
+        return Z_pruned, np.full(m, -2, dtype=np.int64), np.zeros(m, np.float64), F
+    labels_faces, probabilities_faces, *_ = tree_to_labels(
+        single_linkage_tree=Z_pruned,
+        min_cluster_size=min_cluster_size,
+        DBSCAN_threshold=DBSCAN_threshold,
+    )
+    ret_labels = np.full(m, -2, dtype=np.int64)
+    ret_prob = np.zeros(m, dtype=np.float64)
+    ret_labels[surv_idx] = labels_faces
+    ret_prob[surv_idx] = probabilities_faces
+    return Z, ret_labels, ret_prob, F
+
+
+def build_Z_mst_occurrences_components(
+    face_vertices: np.ndarray,
+    mst_faces_sorted: Sequence[tuple[int, int, float]],
+    *,
+    min_cluster_size: int,
+    verbose: bool = False,
+    distinct_mode: str = "owner",
+    DBSCAN_threshold: float | None = None,
+) -> tuple[np.ndarray, list[list[tuple[int, float]]]]:
+    def _fmt_bytes(n: float) -> str:
+        n = float(n)
+        for unit in ("B", "KiB", "MiB", "GiB"):
+            if n < 1024 or unit == "GiB":
+                return f"{n:.1f} {unit}" if unit != "B" else f"{n:.0f} {unit}"
+            n /= 1024
+        return f"{n:.1f} GiB"
+
+    def _rss() -> float | None:
+        try:
+            import psutil
+
+            return float(psutil.Process().memory_info().rss)
+        except Exception:
+            return None
+
+    face_vertices = np.asarray(face_vertices, dtype=np.int64, order="C")
+    n_faces = int(face_vertices.shape[0])
+    if n_faces == 0:
+        return np.zeros(0, dtype=np.int64), []
+    UF_face = UnionFind(n_faces)
+    for u, v, _ in mst_faces_sorted:
+        UF_face.union(u, v)
+    comp_labels = np.fromiter((UF_face.find(i) for i in range(n_faces)), count=n_faces, dtype=np.int64)
+    order_faces = np.argsort(comp_labels, kind="mergesort")
+    labels_sorted = comp_labels[order_faces]
+    diff_faces = labels_sorted[1:] != labels_sorted[:-1]
+    starts = np.r_[0, 1 + np.flatnonzero(diff_faces)]
+    ends = np.r_[starts[1:], labels_sorted.size]
+    uniq = labels_sorted[starts]
+    faces_ordered = np.arange(n_faces, dtype=np.int64)[order_faces]
+    n_points_total = int(face_vertices.max()) + 1
+    labels_points_unique = np.full(n_points_total, -1, dtype=np.int64)
+    labels_points_multiple: list[list[tuple[int, float]]] = [[] for _ in range(n_points_total)]
+    first = np.full(n_points_total, -2, dtype=np.int64)
+    conflict = np.zeros(n_points_total, dtype=bool)
+    next_cluster_id = 0
+    if verbose:
+        r = _rss()
+        if r is not None:
+            print(
+                f"[COMP-F:0] components={uniq.size}, faces={n_faces}, points={n_points_total}, RSS={_fmt_bytes(r)}"
+            )
+    if len(mst_faces_sorted):
+        u_arr = np.asarray([uv[0] for uv in mst_faces_sorted], dtype=np.int64)
+        v_arr = np.asarray([uv[1] for uv in mst_faces_sorted], dtype=np.int64)
+        w_arr = np.asarray([uv[2] for uv in mst_faces_sorted], dtype=np.float64)
+        comp_u = comp_labels[u_arr]
+        order_edges = np.argsort(comp_u, kind="mergesort")
+        comp_u_sorted = comp_u[order_edges]
+        diff_edges = comp_u_sorted[1:] != comp_u_sorted[:-1]
+        starts_e = np.r_[0, 1 + np.flatnonzero(diff_edges)]
+        ends_e = np.r_[starts_e[1:], comp_u_sorted.size]
+        uniq_e = comp_u_sorted[starts_e]
+    else:
+        u_arr = v_arr = np.empty(0, dtype=np.int64)
+        w_arr = np.empty(0, dtype=np.float64)
+        order_edges = np.empty(0, dtype=np.int64)
+        starts_e = ends_e = uniq_e = np.empty(0, dtype=np.int64)
+    for j in range(uniq.size):
+        f_start, f_end = int(starts[j]), int(ends[j])
+        faces = faces_ordered[f_start:f_end]
+        if faces.size == 0:
+            continue
+        comp_id = int(uniq[j])
+        if order_edges.size:
+            pos = np.searchsorted(uniq_e, comp_id)
+            if pos < uniq_e.size and uniq_e[pos] == comp_id:
+                e_start = int(starts_e[pos])
+                e_end = int(ends_e[pos])
+                idx_edges = order_edges[e_start:e_end]
+            else:
+                idx_edges = np.empty(0, dtype=np.int64)
+        else:
+            idx_edges = np.empty(0, dtype=np.int64)
+        faces_sorted = np.sort(faces)
+        u_sel = u_arr[idx_edges]
+        v_sel = v_arr[idx_edges]
+        w_sel = w_arr[idx_edges]
+        new_u = np.searchsorted(faces_sorted, u_sel).astype(np.int64, copy=False)
+        new_v = np.searchsorted(faces_sorted, v_sel).astype(np.int64, copy=False)
+        faces_compact = face_vertices[faces_sorted]
+        if verbose:
+            r = _rss()
+            est_Z = max(0, faces_compact.shape[0] - 1) * 32
+            print(
+                f"[COMP-F:1] comp {j + 1}/{uniq.size} | faces={faces_compact.shape[0]}, edges={new_u.size}, "
+                f"Z_est≈{_fmt_bytes(est_Z)}, RSS={_fmt_bytes(r) if r else 'n/a'}"
+            )
+        Z_i, labels_faces_i, probabilities_faces_i, F_i = build_Z_mst_occurrences_gc(
+            faces_compact,
+            (new_u, new_v, w_sel),
+            min_cluster_size=min_cluster_size,
+            verbose=verbose,
+            distinct_mode=distinct_mode,
+            DBSCAN_threshold=DBSCAN_threshold,
+        )
+        if len(labels_faces_i) and np.any(labels_faces_i != -1):
+            max_local = int(labels_faces_i[labels_faces_i != -1].max())
+            offset = next_cluster_id
+            for f_loc in range(F_i.shape[0]):
+                lbl = int(labels_faces_i[f_loc])
+                if lbl in (-2, -1):
+                    continue
+                lbl_g = lbl + offset
+                row = F_i[f_loc]
+                for t in range(row.size):
+                    v = int(row[t])
+                    labels_points_multiple[v].append((lbl_g, probabilities_faces_i[f_loc]))
+                    if first[v] == -2:
+                        first[v] = lbl_g
+                    elif first[v] != lbl_g:
+                        conflict[v] = True
+            next_cluster_id = offset + max_local + 1
+        if verbose and (j % 1 == 0):
+            valid = (first != -2) & (~conflict)
+            r = _rss()
+            print(
+                f"[COMP-F:2] comp {j + 1}/{uniq.size} done | cumul points labellisés={int(valid.sum())} "
+                f"| conflits={int(conflict.sum())} | RSS={_fmt_bytes(r) if r else 'n/a'}"
+            )
+    mask_ok = (~conflict) & (first != -2)
+    labels_points_unique[mask_ok] = first[mask_ok]
+    ret_labels_points_multiple: list[list[tuple[int, float, float]]] = [[] for _ in range(n_points_total)]
+    for v, labels in enumerate(labels_points_multiple):
+        if not labels:
+            ret_labels_points_multiple[v] = [(-1, 1.0, 1.0)]
+            continue
+        grouped: defaultdict[int, list[float]] = defaultdict(list)
+        for lbl, prob in labels:
+            grouped[lbl].append(prob)
+        aggregated: list[tuple[int, float, float]] = []
+        total = float(len(labels))
+        for lbl, probs in grouped.items():
+            count = len(probs)
+            aggregated.append((lbl, count / total, float(np.mean(probs))))
+        ret_labels_points_multiple[v] = aggregated
+    if verbose:
+        uvals = np.unique(labels_points_unique)
+        r = _rss()
+        print(
+            "Clusters finaux :",
+            uvals[uvals != -1].size,
+            "| bruit :",
+            int(np.sum(labels_points_unique == -1)),
+            f"| RSS={_fmt_bytes(r) if r else 'n/a'}",
+        )
+    return labels_points_unique, ret_labels_points_multiple

--- a/src/hypergraphpercol/core.py
+++ b/src/hypergraphpercol/core.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import itertools
+import math
+import os
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import numpy as np
+from joblib import Parallel, delayed
+from sklearn.decomposition import PCA
+from sklearn.metrics import pairwise_distances
+
+from .clustering import build_Z_mst_occurrences_components, _kruskal_mst_from_edges
+from .delaunay import orderk_delaunay3
+from .geometry import kth_radius, minimum_enclosing_ball
+from .union_find import UnionFind
+
+N_CPU = max(1, os.cpu_count() or 1)
+
+
+def _build_graph_KSimplexes(
+    M: np.ndarray,
+    K: int,
+    min_samples: int,
+    metric: str,
+    complex_chosen: str,
+    expZ: float,
+    precision: str = "safe",
+    verbose: bool = False,
+    cgal_root: str | os.PathLike[str] | None = None,
+) -> tuple[list[list[int]], list[int], list[int], list[float], int]:
+    if min_samples is None or min_samples <= K:
+        min_samples = K + 1
+    pre = metric == "precomputed"
+    delaunay_possible = not pre and metric == "euclidean" and M.ndim == 2 and M.shape[0] != M.shape[1]
+    n, d = M.shape
+    if complex_chosen.lower() not in {"orderk_delaunay", "delaunay", "rips"}:
+        if not delaunay_possible:
+            complex_chosen = "rips"
+        else:
+            if d > 10 and n > 100:
+                complex_chosen = "rips"
+            elif d > 10:
+                complex_chosen = "delaunay"
+            elif d > 5 and n > 1000:
+                complex_chosen = "rips"
+            else:
+                complex_chosen = "orderk_delaunay"
+    Simplexes: list[tuple[list[int], float]] = []
+    root_path = Path(cgal_root) if cgal_root is not None else None
+    if complex_chosen.lower() == "orderk_delaunay":
+        simplexes = orderk_delaunay3(M, min_samples - 1, precision=precision, verbose=verbose, root=root_path)
+        if verbose:
+            print(f"Simplexes sans filtration : {len(simplexes)}")
+        if simplexes:
+            def _sqr_radius(simplex: Sequence[int]) -> float:
+                pts = M[np.asarray(simplex, dtype=np.int64)]
+                _, radius_sq = minimum_enclosing_ball(pts)
+                return radius_sq
+
+            radii_sq = Parallel(n_jobs=N_CPU, prefer="processes")(
+                delayed(_sqr_radius)(s) for s in simplexes
+            )
+            if expZ != 2:
+                radii_sq = np.asarray(radii_sq, dtype=np.float64) ** (expZ / 2)
+            Simplexes = [(list(s), float(radii_sq[i])) for i, s in enumerate(simplexes)]
+    else:
+        import gudhi
+
+        r = kth_radius(M, min_samples - 1, metric, pre)
+        r2 = r**2
+        if complex_chosen.lower() == "rips":
+            r2 = r
+            expZ_local = expZ * 2
+            if precision == "exact":
+                mx = 2 * np.quantile(r, 0.99)
+            else:
+                mx = (1 + 1 / math.sqrt(d)) * np.quantile(r, 0.99)
+            if pre or metric != "euclidean":
+                D = M if pre else pairwise_distances(M, metric=metric)
+                st = gudhi.RipsComplex(distance_matrix=D, max_edge_length=mx).create_simplex_tree(max_dimension=K)
+            else:
+                st = gudhi.RipsComplex(points=M, max_edge_length=mx).create_simplex_tree(max_dimension=K)
+        else:
+            expZ_local = expZ
+            st = gudhi.DelaunayCechComplex(points=M).create_simplex_tree()
+        for simplex, filt in st.get_skeleton(K):
+            if len(simplex) != K + 1:
+                continue
+            simplex = list(sorted(simplex))
+            max_kth_radius2 = max(r2[p] for p in simplex)
+            filt = max(filt, max_kth_radius2)
+            if expZ_local != 2:
+                filt = filt ** (expZ_local / 2)
+            Simplexes.append((simplex, float(filt)))
+    faces_raw: list[list[int]] = []
+    e_u: list[int] = []
+    e_v: list[int] = []
+    e_w: list[float] = []
+    nS = 0
+    for simplex, weight in Simplexes:
+        if len(simplex) <= K:
+            continue
+        for vertices in itertools.combinations(range(len(simplex)), K + 1):
+            nS += 1
+            vert = tuple(sorted(vertices))
+            base = len(faces_raw)
+            for drop in range(K + 1):
+                face = [simplex[vert[i]] for i in range(K + 1) if i != drop]
+                faces_raw.append(face)
+            for idx in range(K):
+                e_u.append(base + idx)
+                e_v.append(base + idx + 1)
+                e_w.append(float(weight))
+    return faces_raw, e_u, e_v, e_w, nS
+
+
+def HypergraphPercol(
+    M: np.ndarray,
+    K: int = 2,
+    min_cluster_size: int | None = None,
+    min_samples: int | None = None,
+    metric: str = "euclidean",
+    DBSCAN_threshold: float | None = None,
+    label_all_points: bool = False,
+    return_multi_clusters: bool = False,
+    complex_chosen: str = "auto",
+    expZ: float = 2,
+    precision: str = "safe",
+    dim_reducer: bool | str = False,
+    threshold_variance_dim_reduction: float = 0.999,
+    verbeux: bool = False,
+    cgal_root: str | os.PathLike[str] | None = None,
+) -> np.ndarray | tuple[np.ndarray, list[list[tuple[int, float, float]]]]:
+    n, d = M.shape
+    M = np.ascontiguousarray(M, dtype=np.float64)
+    if min_cluster_size is None:
+        min_cluster_size = round(math.sqrt(n))
+    X = np.copy(M)
+    pre = metric == "precomputed"
+    delaunay_possible = not pre and metric == "euclidean" and M.ndim == 2 and M.shape[0] != M.shape[1]
+    if min_samples is None or min_samples <= K:
+        min_samples = K + 1
+    if str(dim_reducer).lower() in {"pca", "umap"} and delaunay_possible:
+        pca = PCA(n_components=threshold_variance_dim_reduction, svd_solver="full", whiten=False)
+        X2 = pca.fit_transform(M)
+        r = pca.n_components_
+        ratio = pca.explained_variance_ratio_.sum()
+        if r < d and str(dim_reducer).lower() == "pca":
+            X = X2
+            if verbeux:
+                print(f"Dimension réduite par PCA : {d} → {r} (variance {ratio:.3f})")
+        elif r < d and str(dim_reducer).lower() == "umap":
+            from umap import UMAP
+
+            reducer = UMAP(n_components=r, n_neighbors=max(2 * 2 * (K + 1), min_samples), metric=metric)
+            X = reducer.fit_transform(M)
+            if verbeux:
+                print(f"Dimension réduite par UMAP : {d} → {r}")
+    faces_raw, e_u, e_v, e_w, nS = _build_graph_KSimplexes(
+        X,
+        K,
+        min_samples,
+        metric,
+        complex_chosen,
+        expZ,
+        precision=precision,
+        verbose=verbeux,
+        cgal_root=cgal_root,
+    )
+    if verbeux:
+        print(f"{K}-simplices={nS}")
+    if not faces_raw:
+        if K > d:
+            print("Warning: K too high compared to the dimension of the data. No clustering possible with such a K.")
+        if return_multi_clusters:
+            return np.full(n, -1, dtype=np.int64), [(-1, 1.0, 1.0)] * n
+        return np.full(n, 0, dtype=np.int64)
+    faces_raw_arr = np.asarray(faces_raw, dtype=np.int64, order="C")
+    e_u_arr = np.asarray(e_u, dtype=np.int64)
+    e_v_arr = np.asarray(e_v, dtype=np.int64)
+    e_w_arr = np.asarray(e_w, dtype=np.float64)
+    faces_unique, inv = np.unique(faces_raw_arr, axis=0, return_inverse=True)
+    if verbeux:
+        print(f"Faces uniques: {faces_unique.shape[0]} (compression {faces_raw_arr.shape[0]}→{faces_unique.shape[0]})")
+    u = inv[e_u_arr]
+    v = inv[e_v_arr]
+    w = e_w_arr
+    uu = np.minimum(u, v)
+    vv = np.maximum(u, v)
+    order = np.lexsort((vv, uu))
+    uu = uu[order]
+    vv = vv[order]
+    ww = w[order]
+    change = np.r_[True, (uu[1:] != uu[:-1]) | (vv[1:] != vv[:-1])]
+    gidx = np.flatnonzero(change)
+    ww = np.minimum.reduceat(ww, gidx)
+    uu = uu[gidx]
+    vv = vv[gidx]
+    if verbeux:
+        print(f"Arêtes uniques (u<v): {uu.size} (avant dédup {u.size})")
+    UF_faces = UnionFind(faces_unique.shape[0])
+    mst_faces_sorted = _kruskal_mst_from_edges(faces_unique.shape[0], uu, vv, ww, UF_faces)
+    if verbeux:
+        m = faces_unique.shape[0]
+        e_mst = len(mst_faces_sorted)
+        comps = max(0, m - e_mst) if m else 0
+        print(f"MST faces: {e_mst} arêtes, composantes estimées: {comps}")
+    labels_points_unique, labels_points_multiple = build_Z_mst_occurrences_components(
+        faces_unique,
+        mst_faces_sorted,
+        min_cluster_size=min_cluster_size,
+        verbose=verbeux,
+        distinct_mode="owner",
+        DBSCAN_threshold=DBSCAN_threshold,
+    )
+    labels_points_unique = np.asarray(labels_points_unique)
+
+    def knn_fill_weighted(X_data: np.ndarray, labels: np.ndarray, k: int) -> np.ndarray:
+        from sklearn.neighbors import KNeighborsClassifier
+
+        X_data = np.asarray(X_data)
+        y = labels.copy()
+        mask_u = y == -1
+        if not mask_u.any():
+            return y
+        mask_l = ~mask_u
+        if not mask_l.any():
+            return y
+        k = min(k, int(mask_l.sum()))
+        clf = KNeighborsClassifier(n_neighbors=k, weights="distance", n_jobs=-1)
+        clf.fit(X_data[mask_l], y[mask_l])
+        y[mask_u] = clf.predict(X_data[mask_u])
+        return y
+
+    if label_all_points and delaunay_possible:
+        labels_points_unique = knn_fill_weighted(M, labels_points_unique, min_samples)
+    if return_multi_clusters:
+        return labels_points_unique, labels_points_multiple
+    return labels_points_unique

--- a/src/hypergraphpercol/delaunay.py
+++ b/src/hypergraphpercol/delaunay.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import numpy as np
+
+from .geometry import bary_weight_batch, union_if_adjacent_int
+
+
+def unique_sorted_rows(arr: np.ndarray, *, sort_rows: bool = False) -> np.ndarray:
+    a = np.asarray(arr, dtype=np.int64)
+    if a.ndim != 2:
+        raise ValueError("unique_sorted_rows expects a 2D array")
+    if a.shape[0] == 0:
+        return a.reshape(0, a.shape[1])
+    if sort_rows:
+        order = np.lexsort(a.T[::-1])
+        a = np.ascontiguousarray(a[order])
+    else:
+        a = np.ascontiguousarray(a)
+    keep = np.ones(a.shape[0], dtype=bool)
+    if a.shape[0] > 1:
+        keep[1:] = np.any(a[1:] != a[:-1], axis=1)
+    return a[keep]
+
+
+def _resolve_cgal_binary(dimension: int, weighted: bool, root: Path) -> Path:
+    base = "EdgesCGALWeightedDelaunay" if weighted else "EdgesCGALDelaunay"
+    if dimension in (2, 3):
+        suffix = f"{dimension}D"
+    else:
+        suffix = "ND"
+    binary = root / f"{base}{suffix}" / "build" / f"{base}{suffix}"
+    if not binary.exists():
+        raise FileNotFoundError(f"CGAL binary not found: {binary}. Run `scripts/setup_cgal.py`.")
+    return binary
+
+
+def edges_from_weighted_delaunay(points: np.ndarray, weights: np.ndarray | None = None, *, precision: str = "safe", root: Path | None = None) -> list[tuple[int, int]]:
+    points = np.asarray(points, dtype=np.float64)
+    if points.ndim != 2:
+        raise ValueError("points must be a 2D array")
+    weights_arr = None if weights is None else np.asarray(weights, dtype=np.float64)
+    if weights_arr is not None and weights_arr.shape[0] != points.shape[0]:
+        raise ValueError("weights must have the same length as points")
+    dimension = points.shape[1]
+    root_dir = root or os.environ.get("CGALDELAUNAY_ROOT")
+    if root_dir is None:
+        root_dir = Path(__file__).resolve().parents[2] / "CGALDelaunay"
+    else:
+        root_dir = Path(root_dir)
+    binary = _resolve_cgal_binary(dimension, weights_arr is not None, root_dir)
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        points_file = tmp_path / "points.npy"
+        output_file = tmp_path / "edges.npy"
+        np.save(points_file, points)
+        cmd: list[str] = [str(binary), str(points_file), str(output_file)]
+        if weights_arr is not None:
+            weights_file = tmp_path / "weights.npy"
+            np.save(weights_file, weights_arr)
+            cmd.insert(2, str(weights_file))
+        env = os.environ.copy()
+        if precision == "exact":
+            env["CGAL_EXACT_PREDICATES"] = "1"
+        subprocess.run(cmd, check=True, env=env)
+        edges = np.load(output_file)
+    edges = np.asarray(edges, dtype=np.int64)
+    if edges.size == 0:
+        return []
+    edges.sort(axis=1)
+    edges = unique_sorted_rows(edges, sort_rows=False)
+    return [(int(i), int(j)) for i, j in edges]
+
+
+def _build_all_keys(combos: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    combos = np.asarray(combos, dtype=np.int64)
+    if combos.ndim != 2:
+        raise ValueError("combos must be a 2D array")
+    m, k = combos.shape
+    if k < 2:
+        return np.empty((0, 0), dtype=np.int64), np.empty((0,), dtype=np.int64)
+    keys = []
+    parents = []
+    for r in range(k):
+        mask = [c for c in range(k) if c != r]
+        keys.append(combos[:, mask])
+        parents.append(np.arange(m, dtype=np.int64))
+    all_keys = np.vstack(keys).astype(np.int64, copy=False)
+    parent_idx = np.concatenate(parents).astype(np.int64, copy=False)
+    return all_keys, parent_idx
+
+
+def orderk_delaunay3(
+    M: np.ndarray,
+    K: int,
+    *,
+    precision: str = "safe",
+    verbose: bool = False,
+    root: Path | None = None,
+) -> list[list[int]]:
+    M = np.ascontiguousarray(M, dtype=np.float64)
+    if M.ndim != 2:
+        raise ValueError("M must be 2D")
+    if K < 1:
+        raise ValueError("K must be >= 1")
+    n, d = M.shape
+    if n < 2:
+        return []
+    s2_all = (M * M).sum(axis=1)
+    prev = edges_from_weighted_delaunay(M, precision=precision, root=root)
+    if verbose:
+        print("orderk_delaunay k = 1")
+    if K == 1:
+        return [list(edge) for edge in prev]
+    prev_array = np.asarray(prev, dtype=np.int64)
+    for k in range(2, K + 1):
+        if prev_array.shape[0] < 2:
+            return []
+        combos = np.ascontiguousarray(prev_array, dtype=np.int64)
+        Q = np.empty((combos.shape[0], d), dtype=np.float64)
+        w = np.empty((combos.shape[0],), dtype=np.float64)
+        bary_weight_batch(M, s2_all, combos, Q, w)
+        if verbose:
+            print("Computed weighted barycentres", Q.shape[0])
+        edges = edges_from_weighted_delaunay(Q, w, precision=precision, root=root)
+        if not edges:
+            return []
+        next_candidates: list[np.ndarray] = []
+        buffer = np.empty(k + 1, dtype=np.int64)
+        for i, j in edges:
+            A = combos[i]
+            B = combos[j]
+            if union_if_adjacent_int(A, B, buffer):
+                next_candidates.append(buffer.copy())
+        if not next_candidates:
+            return []
+        prev_array = unique_sorted_rows(np.asarray(next_candidates, dtype=np.int64), sort_rows=False)
+        if verbose:
+            print(f"orderk_delaunay k = {k}")
+    return prev_array.tolist()

--- a/src/hypergraphpercol/geometry.py
+++ b/src/hypergraphpercol/geometry.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import numpy as np
+
+try:  # pragma: no cover - prefer compiled implementations
+    from ._cython import (  # type: ignore
+        bary_weight_batch as _cython_bary_weight_batch,
+        bary_weight_one as _cython_bary_weight_one,
+        union_if_adjacent_int as _cython_union_if_adjacent_int,
+    )
+except ImportError:  # pragma: no cover - fallback used when extension unavailable
+    _cython_bary_weight_one = None
+    _cython_bary_weight_batch = None
+    _cython_union_if_adjacent_int = None
+
+def bary_weight_one(
+    M: np.ndarray,
+    s2_all: np.ndarray,
+    idx: np.ndarray,
+    out_q: np.ndarray,
+) -> float:
+    if _cython_bary_weight_one is not None:
+        return float(_cython_bary_weight_one(M, s2_all, idx, out_q))
+    idx_arr = np.asarray(idx, dtype=np.int64)
+    points = M[idx_arr]
+    np.copyto(out_q, points.mean(axis=0))
+    qnorm2 = float(np.dot(out_q, out_q))
+    return qnorm2 - float(np.asarray(s2_all, dtype=np.float64)[idx_arr].mean())
+
+
+def bary_weight_batch(
+    M: np.ndarray,
+    s2_all: np.ndarray,
+    combos: np.ndarray,
+    out_Q: np.ndarray,
+    out_w: np.ndarray,
+) -> None:
+    if _cython_bary_weight_batch is not None:
+        _cython_bary_weight_batch(M, s2_all, combos, out_Q, out_w)
+        return
+    for i, combo in enumerate(combos):
+        points = M[combo]
+        mean = points.mean(axis=0)
+        out_Q[i] = mean
+        out_w[i] = float(np.dot(mean, mean) - s2_all[combo].mean())
+
+
+def union_if_adjacent_int(a: np.ndarray, b: np.ndarray, out_u: np.ndarray) -> bool:
+    if _cython_union_if_adjacent_int is not None:
+        return bool(_cython_union_if_adjacent_int(a, b, out_u))
+    i = j = u = 0
+    k = a.shape[0]
+    while i < k and j < k:
+        if u >= out_u.shape[0]:
+            return False
+        ai = int(a[i])
+        bj = int(b[j])
+        if ai == bj:
+            out_u[u] = ai
+            i += 1
+            j += 1
+        elif ai < bj:
+            out_u[u] = ai
+            i += 1
+        else:
+            out_u[u] = bj
+            j += 1
+        u += 1
+    while i < k:
+        if u >= out_u.shape[0]:
+            return False
+        out_u[u] = int(a[i])
+        i += 1
+        u += 1
+    while j < k:
+        if u >= out_u.shape[0]:
+            return False
+        out_u[u] = int(b[j])
+        j += 1
+        u += 1
+    return u == k + 1
+
+
+def minimum_enclosing_ball(points_sub: np.ndarray) -> tuple[np.ndarray, float]:
+    if points_sub.shape[0] <= 1:
+        return points_sub[0], 0.0
+    if points_sub.shape[0] == 2:
+        diff = points_sub[0] - points_sub[1]
+        return 0.5 * (points_sub[0] + points_sub[1]), float(np.dot(diff, diff)) * 0.25
+    import miniball
+
+    ball = miniball.Miniball(points_sub)
+    return np.asarray(ball.center(), dtype=np.float64), float(ball.squared_radius())
+
+
+def kth_radius(M: np.ndarray, k: int, metric: str, precomputed: bool) -> np.ndarray:
+    if precomputed:
+        return np.partition(M, k, axis=1)[:, k]
+    from sklearn.neighbors import NearestNeighbors
+
+    nn = NearestNeighbors(n_neighbors=k + 1, metric=metric).fit(M)
+    dists, _ = nn.kneighbors(M)
+    return dists[:, k]

--- a/src/hypergraphpercol/union_find.py
+++ b/src/hypergraphpercol/union_find.py
@@ -1,0 +1,43 @@
+"""Union-Find data structure with a Cython-accelerated implementation."""
+
+from __future__ import annotations
+
+import numpy as np
+
+try:  # pragma: no cover - exercised via compiled extension
+    from ._cython import UnionFind as _CythonUnionFind  # type: ignore
+except ImportError:  # pragma: no cover - fallback used when extension unavailable
+    class _CythonUnionFind:  # type: ignore[too-many-ancestors]
+        def __init__(self, size: int) -> None:
+            if size < 0:
+                raise ValueError("size must be non-negative")
+            self.parent = np.arange(size, dtype=np.int64)
+            self._size = np.ones(size, dtype=np.int64)
+
+        def find(self, x: int) -> int:
+            parent = self.parent
+            while parent[x] != x:
+                parent[x] = parent[parent[x]]
+                x = parent[x]
+            return int(x)
+
+        def union(self, a: int, b: int) -> bool:
+            ra = self.find(a)
+            rb = self.find(b)
+            if ra == rb:
+                return False
+            size = self._size
+            if size[ra] < size[rb]:
+                ra, rb = rb, ra
+            parent = self.parent
+            parent[rb] = ra
+            size[ra] += size[rb]
+            return True
+
+        def component_size(self, x: int) -> int:
+            return int(self._size[self.find(x)])
+
+
+UnionFind = _CythonUnionFind
+
+__all__ = ["UnionFind"]

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,11 @@
+import importlib
+
+import pytest
+
+
+def test_import_package():
+    try:
+        module = importlib.import_module("hypergraphpercol")
+    except ModuleNotFoundError as exc:  # pragma: no cover
+        pytest.skip(f"Missing dependency: {exc.name}")
+    assert hasattr(module, "HypergraphPercol")


### PR DESCRIPTION
## Summary
- add a Cython extension module implementing the accelerated union-find, barycentric weight, and leaf DFS utilities and wire them into the package with Python fallbacks
- update the geometry, clustering, and union-find modules plus the README to document and default to the compiled implementations
- extend the build configuration with Cython/numpy requirements and a setup.py to compile the extension during installation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d66343cbec8326af77bfb2797930c0